### PR TITLE
Add logic for Conjured Mana Cake

### DIFF
--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -25,44 +25,51 @@ export class GildedRose {
 
       this.items[i].sellIn = this.items[i].sellIn - 1;
 
-      if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-        if (this.items[i].sellIn < 0) {
-          this.items[i].quality = 0
-          continue;
-        }
+      switch (this.items[i].name) {
+        case 'Backstage passes to a TAFKAL80ETC concert':
+          if (this.items[i].sellIn < 0) {
+            this.items[i].quality = 0
+            break;
+          }
 
-        if (this.items[i].sellIn >= 10) {
-          this.items[i].quality = this.items[i].quality + 1
-        }
-        else if (this.items[i].sellIn >= 5) {
-          this.items[i].quality = this.items[i].quality + 2
-        }
-        else {
-          this.items[i].quality = this.items[i].quality + 3
-        }
+          if (this.items[i].sellIn >= 10) {
+            this.items[i].quality = this.items[i].quality + 1
+          }
+          else if (this.items[i].sellIn >= 5) {
+            this.items[i].quality = this.items[i].quality + 2
+          }
+          else {
+            this.items[i].quality = this.items[i].quality + 3
+          }
 
-        if (this.items[i].quality > 50) {
-          this.items[i].quality = 50
-        }
-        continue;
-      }
-
-
-      if (this.items[i].name === 'Aged Brie') {
-        if (this.items[i].sellIn < 0) {
-          this.items[i].quality = Math.min(this.items[i].quality + 2, 50);
-        }
-        else {
-          this.items[i].quality = Math.min(this.items[i].quality + 1, 50);
-        }
-        continue;
-      }
-
-      if (this.items[i].sellIn < 0) {
-        this.items[i].quality = Math.max(0, this.items[i].quality - 2);
-      }
-      else {
-        this.items[i].quality = Math.max(0, this.items[i].quality - 1);
+          if (this.items[i].quality > 50) {
+            this.items[i].quality = 50
+          }
+          break;
+        case 'Aged Brie':
+          if (this.items[i].sellIn < 0) {
+            this.items[i].quality = Math.min(this.items[i].quality + 2, 50);
+          }
+          else {
+            this.items[i].quality = Math.min(this.items[i].quality + 1, 50);
+          }
+          break;
+        case 'Conjured Mana Cake':
+          if (this.items[i].sellIn < 0) {
+            this.items[i].quality = Math.max(0, this.items[i].quality - 4);
+          }
+          else {
+            this.items[i].quality = Math.max(0, this.items[i].quality - 2);
+          }
+          break;
+        default:
+          if (this.items[i].sellIn < 0) {
+            this.items[i].quality = Math.max(0, this.items[i].quality - 2);
+          }
+          else {
+            this.items[i].quality = Math.max(0, this.items[i].quality - 1);
+          }
+          break;
       }
     }
     return this.items;

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -19,54 +19,49 @@ export class GildedRose {
 
   updateQuality() {
     for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].name === 'Sulfuras, Hand of Ragnaros') {
+      if (this.items[i].name === "Sulfuras, Hand of Ragnaros") {
         continue;
       }
 
       this.items[i].sellIn = this.items[i].sellIn - 1;
 
       switch (this.items[i].name) {
-        case 'Backstage passes to a TAFKAL80ETC concert':
+        case "Backstage passes to a TAFKAL80ETC concert":
           if (this.items[i].sellIn < 0) {
-            this.items[i].quality = 0
+            this.items[i].quality = 0;
             break;
           }
 
           if (this.items[i].sellIn >= 10) {
-            this.items[i].quality = this.items[i].quality + 1
-          }
-          else if (this.items[i].sellIn >= 5) {
-            this.items[i].quality = this.items[i].quality + 2
-          }
-          else {
-            this.items[i].quality = this.items[i].quality + 3
+            this.items[i].quality = this.items[i].quality + 1;
+          } else if (this.items[i].sellIn >= 5) {
+            this.items[i].quality = this.items[i].quality + 2;
+          } else {
+            this.items[i].quality = this.items[i].quality + 3;
           }
 
           if (this.items[i].quality > 50) {
-            this.items[i].quality = 50
+            this.items[i].quality = 50;
           }
           break;
-        case 'Aged Brie':
+        case "Aged Brie":
           if (this.items[i].sellIn < 0) {
             this.items[i].quality = Math.min(this.items[i].quality + 2, 50);
-          }
-          else {
+          } else {
             this.items[i].quality = Math.min(this.items[i].quality + 1, 50);
           }
           break;
-        case 'Conjured Mana Cake':
+        case "Conjured Mana Cake":
           if (this.items[i].sellIn < 0) {
             this.items[i].quality = Math.max(0, this.items[i].quality - 4);
-          }
-          else {
+          } else {
             this.items[i].quality = Math.max(0, this.items[i].quality - 2);
           }
           break;
         default:
           if (this.items[i].sellIn < 0) {
             this.items[i].quality = Math.max(0, this.items[i].quality - 2);
-          }
-          else {
+          } else {
             this.items[i].quality = Math.max(0, this.items[i].quality - 1);
           }
           break;

--- a/TypeScript/test/jest/__snapshots__/approvals.spec.ts.snap
+++ b/TypeScript/test/jest/__snapshots__/approvals.spec.ts.snap
@@ -34,7 +34,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 4
 
 -------- day 2 --------
 name, sellIn, quality
@@ -46,7 +46,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 2
 
 -------- day 3 --------
 name, sellIn, quality
@@ -58,7 +58,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 0
 
 -------- day 4 --------
 name, sellIn, quality
@@ -70,7 +70,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -1,7 +1,5 @@
 import { Item, GildedRose } from '@/gilded-rose';
 
-const POSSIBLE_ITEMS: String[] = ['Aged Brie', 'Sulfuras, Hand of Ragnaros', 'Backstage passes to a TAFKAL80ETC concert', 'Conjured Mana Cake']
-
 type expectedValuesAfterUpdateSet = [name: string, sellIn: number, quality: number, expectedSellIn: number, expectedQuality: number];
 
 it.each<expectedValuesAfterUpdateSet>([

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -1,14 +1,6 @@
 import { Item, GildedRose } from '@/gilded-rose';
 
-const POSSIBLE_ITEMS: String[] = ['Aged Brie', 'Sulfuras, Hand of Ragnaros', 'Backstage passes to a TAFKAL80ETC concert']
-
-// describe('Gilded Rose', () => {
-//   it('should foo', () => {
-//     const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
-//     const items = gildedRose.updateQuality();
-//     expect(items[0].name).toBe('foo');
-//   });
-// });
+const POSSIBLE_ITEMS: String[] = ['Aged Brie', 'Sulfuras, Hand of Ragnaros', 'Backstage passes to a TAFKAL80ETC concert', 'Conjured Mana Cake']
 
 type expectedValuesAfterUpdateSet = [name: string, sellIn: number, quality: number, expectedSellIn: number, expectedQuality: number];
 
@@ -18,7 +10,7 @@ it.each<expectedValuesAfterUpdateSet>([
   ['Base Case Item - at zero boundary', 1, 1, 0, 0],        //at zero boundary
   ['Base Case Item - twice the speed', 0, 6, -1, 4],        //twice the speed
   ['Base Case Item - sellIn goes negative', 0, 1, -1, 0],   //sellIn goes negative
-  ['Aged Brie', 15, 5, 14, 6],                             //Brie increases in 
+  ['Aged Brie', 15, 5, 14, 6],                              //Brie increases in 
   ['Aged Brie', 0, 5, -1, 7],                               //Out of date brie twice as good
   ['Aged Brie', -9, 5, -10, 7],                             //Long out of date brie twice as good
   ['Aged Brie', -9, 50, -10, 50],                           //Long out of date brie twice as good
@@ -34,6 +26,9 @@ it.each<expectedValuesAfterUpdateSet>([
   ['Backstage passes to a TAFKAL80ETC concert', 5, 49, 4, 50], // more than 5 days but quality at max
   ['Backstage passes to a TAFKAL80ETC concert', 1, 49, 0, 50], // more than one day but quality at max
   ['Backstage passes to a TAFKAL80ETC concert', 0, 49, -1, 0], // day has passed but quality at max
+  ['Conjured Mana Cake', 3, 6, 2, 4],                        //Conjured item standard speed
+  ['Conjured Mana Cake', 0, 6, -1, 2],                       //Conjured item twice the speed
+  ['Conjured Mana Cake', 0, 3, -1, 0],                       //Conjured item twice the speed but not below zero
 ])('should return %s %i %i %i %i', (name, sellIn, quality, expectedSellIn, expectedQuality) => {
   const gildedRose = new GildedRose([new Item(name, sellIn, quality)]);
   const items = gildedRose.updateQuality();
@@ -176,5 +171,41 @@ describe('updateQuality', () => {
     expect(items[0].name).toBe('Aged Brie');
     expect(items[0].sellIn).toBe(-8);
     expect(items[0].quality).toBe(50);
+  });
+
+  test('should decrease in sellIn and decrease quality by 2 if item is Conjured Mana Cake', () => {
+    const gildedRose = new GildedRose([new Item(
+      'Conjured Mana Cake',
+      3,
+      6
+    )]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].name).toBe('Conjured Mana Cake');
+    expect(items[0].sellIn).toBe(2);
+    expect(items[0].quality).toBe(4);
+  });
+
+  test('should decrease in sellIn and decrease quality by 4 if SellIn negative and item is Conjured Mana Cake', () => {
+    const gildedRose = new GildedRose([new Item(
+      'Conjured Mana Cake',
+      -1,
+      6
+    )]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].name).toBe('Conjured Mana Cake');
+    expect(items[0].sellIn).toBe(-2);
+    expect(items[0].quality).toBe(2);
+  });
+
+  test('should stop decrease when quality is 0 and item is Conjured Mana Cake', () => {
+    const gildedRose = new GildedRose([new Item(
+      'Conjured Mana Cake',
+      3,
+      0
+    )]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].name).toBe('Conjured Mana Cake');
+    expect(items[0].sellIn).toBe(2);
+    expect(items[0].quality).toBe(0);
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
Add logic for  `Conjured Mana Cake`. This item depreciates in quality twice as fast as a standard item.
`Conjured Mana Cake` has a depreciation of `2` if the `sellIn` is `>=0` and a depreciation of `4` is the `sellIn` date is `<0`.

## Resolution :heavy_check_mark:
- Added units tests to capture the expected behavior.
- Added a switch case to `updateQuality` to set behavior for non standard items.
- If the item is a `Conjured Mana Cake`, depreciate the quality at twice the rate of a standard item.

## Note :warning:
- The snapshot test was updated to reflect the new functionality.